### PR TITLE
Restore 'command' for FrameworkProcessors

### DIFF
--- a/src/sagemaker/mxnet/processing.py
+++ b/src/sagemaker/mxnet/processing.py
@@ -34,6 +34,7 @@ class MXNetProcessor(FrameworkProcessor):
         instance_type,
         py_version="py3",  # New kwarg
         image_uri=None,
+        command=["python"],
         volume_size_in_gb=30,
         volume_kms_key=None,
         output_kms_key=None,
@@ -66,6 +67,7 @@ class MXNetProcessor(FrameworkProcessor):
             instance_type,
             py_version,
             image_uri,
+            command,
             volume_size_in_gb,
             volume_kms_key,
             output_kms_key,

--- a/src/sagemaker/pytorch/processing.py
+++ b/src/sagemaker/pytorch/processing.py
@@ -34,6 +34,7 @@ class PyTorchProcessor(FrameworkProcessor):
         instance_type,
         py_version="py3",  # New kwarg
         image_uri=None,
+        command=["python"],
         volume_size_in_gb=30,
         volume_kms_key=None,
         output_kms_key=None,
@@ -66,6 +67,7 @@ class PyTorchProcessor(FrameworkProcessor):
             instance_type,
             py_version,
             image_uri,
+            command,
             volume_size_in_gb,
             volume_kms_key,
             output_kms_key,

--- a/src/sagemaker/sklearn/processing.py
+++ b/src/sagemaker/sklearn/processing.py
@@ -48,6 +48,7 @@ class SKLearnProcessor(FrameworkProcessor):
         instance_type,
         py_version="py3",  # New kwarg
         image_uri=None,
+        command=["python"],
         volume_size_in_gb=30,
         volume_kms_key=None,
         output_kms_key=None,
@@ -68,6 +69,7 @@ class SKLearnProcessor(FrameworkProcessor):
             instance_type,
             py_version,
             image_uri,
+            command,
             volume_size_in_gb,
             volume_kms_key,
             output_kms_key,

--- a/src/sagemaker/tensorflow/processing.py
+++ b/src/sagemaker/tensorflow/processing.py
@@ -34,6 +34,7 @@ class TensorFlowProcessor(FrameworkProcessor):
         instance_type,
         py_version="py3",  # New kwarg
         image_uri=None,
+        command=["python"],
         volume_size_in_gb=30,
         volume_kms_key=None,
         output_kms_key=None,
@@ -66,6 +67,7 @@ class TensorFlowProcessor(FrameworkProcessor):
             instance_type,
             py_version,
             image_uri,
+            command,
             volume_size_in_gb,
             volume_kms_key,
             output_kms_key,

--- a/src/sagemaker/xgboost/processing.py
+++ b/src/sagemaker/xgboost/processing.py
@@ -34,6 +34,7 @@ class XGBoostEstimator(FrameworkProcessor):
         instance_type,
         py_version="py3",  # New kwarg
         image_uri=None,
+        command=["python"],
         volume_size_in_gb=30,
         volume_kms_key=None,
         output_kms_key=None,
@@ -66,6 +67,7 @@ class XGBoostEstimator(FrameworkProcessor):
             instance_type,
             py_version,
             image_uri,
+            command,
             volume_size_in_gb,
             volume_kms_key,
             output_kms_key,


### PR DESCRIPTION
**Issue #, if available:** #1 (Addresses, but probably needs some additional tests to fully close out)

**Description of changes:**

- `FrameworkProcessor` (and children) now accept a `command` param like the `ScriptProcessor` did previously, which is an array of executable + parameters substituted in the `runproc.sh` script before the user script name.
- To try and maintain API compatibility, this `command` is actually passed up to the `ScriptProcessor` parent but then overridden in the `_set_entrypoint` method that's used to define the job definition in API.
- Refactored the static `runproc_sh` string template constant to a documented`_generate_framework_script()` method in the hope that the script generation procedure might be more modularly testable, and derived classes to override if they need to.

The current `_generate_framework_script(user_script: str) -> str` + `framework_entrypoint_command` should together make it straightforward enough for a user to derive a child of `FrameworkProcessor` that, for example, used a single Python script as its framework implementation instead of a single shell script.

**Testing done:**

- All unit tests pass, including some minor extensions to existing tests intended to exercise the `command` functionality and check `instance_type=2` is supported.
- Existing integration tests seem to still work fine (and should be unaffected).

**Caveats & limitations:**

- Only unit tested with non-default values for now
- What happens with the existing containers if `python3` is used? Are people used to using that? Need to double-check with integration tests whether the behaviour is actually compatible with previous usage.