### PR TITLE
FrameworkProcessor: revert `run(entry_point=...)` back to `run(code=...)`

### DIFF
--- a/src/sagemaker/mxnet/processing.py
+++ b/src/sagemaker/mxnet/processing.py
@@ -50,7 +50,7 @@ class MXNetProcessor(FrameworkProcessor):
 
         Unless ``image_uri`` is specified, the MXNet environment is an
         Amazon-built Docker container that executes functions defined in the supplied
-        ``entry_point`` Python script.
+        ``code`` Python script.
 
         The arguments have the exact same meaning as in ``FrameworkProcessor``.
 

--- a/src/sagemaker/pytorch/processing.py
+++ b/src/sagemaker/pytorch/processing.py
@@ -50,7 +50,7 @@ class PyTorchProcessor(FrameworkProcessor):
 
         Unless ``image_uri`` is specified, the PyTorch environment is an
         Amazon-built Docker container that executes functions defined in the supplied
-        ``entry_point`` Python script.
+        ``code`` Python script.
 
         The arguments have the exact same meaning as in ``FrameworkProcessor``.
 

--- a/src/sagemaker/sklearn/processing.py
+++ b/src/sagemaker/sklearn/processing.py
@@ -28,7 +28,7 @@ class SKLearnProcessor(FrameworkProcessor):
 
     Unless ``image_uri`` is specified, the scikit-learn environment is an
     Amazon-built Docker container that executes functions defined in the supplied
-    ``entry_point`` Python script.
+    ``code`` Python script.
 
     The arguments have the exact same meaning as in ``FrameworkProcessor``.
 

--- a/src/sagemaker/tensorflow/processing.py
+++ b/src/sagemaker/tensorflow/processing.py
@@ -50,7 +50,7 @@ class TensorFlowProcessor(FrameworkProcessor):
 
         Unless ``image_uri`` is specified, the TensorFlow environment is an
         Amazon-built Docker container that executes functions defined in the supplied
-        ``entry_point`` Python script.
+        ``code`` Python script.
 
         The arguments have the exact same meaning as in ``FrameworkProcessor``.
 

--- a/src/sagemaker/xgboost/processing.py
+++ b/src/sagemaker/xgboost/processing.py
@@ -49,7 +49,7 @@ class XGBoostEstimator(FrameworkProcessor):
         """This processor executes a Python script in an XGBoost execution environment.
 
         Unless ``image_uri`` is specified, the XGBoost environment is an Amazon-built
-        Docker container that executes functions defined in the supplied ``entry_point``
+        Docker container that executes functions defined in the supplied ``code``
         Python script.
 
         The arguments have the exact same meaning as in ``FrameworkProcessor``.

--- a/tests/integ/test_processing.py
+++ b/tests/integ/test_processing.py
@@ -130,7 +130,7 @@ def test_sklearn(sagemaker_session, sklearn_latest_version, cpu_instance_type):
     )
 
     sklearn_processor.run(
-        entry_point=script_path,
+        code=script_path,
         inputs=[ProcessingInput(source=input_file_path, destination="/opt/ml/processing/inputs/")],
         wait=False,
         logs=False,
@@ -174,7 +174,7 @@ def test_sklearn_with_customizations(
     )
 
     sklearn_processor.run(
-        entry_point=os.path.join(DATA_DIR, "dummy_script.py"),
+        code=os.path.join(DATA_DIR, "dummy_script.py"),
         inputs=[
             ProcessingInput(
                 source=input_file_path,
@@ -258,7 +258,7 @@ def test_sklearn_with_custom_default_bucket(
     )
 
     sklearn_processor.run(
-        entry_point=os.path.join(DATA_DIR, "dummy_script.py"),
+        code=os.path.join(DATA_DIR, "dummy_script.py"),
         inputs=[
             ProcessingInput(
                 source=input_file_path,
@@ -338,7 +338,7 @@ def test_sklearn_with_no_inputs_or_outputs(
     )
 
     sklearn_processor.run(
-        entry_point=os.path.join(DATA_DIR, "dummy_script.py"),
+        code=os.path.join(DATA_DIR, "dummy_script.py"),
         arguments=["-v"],
         wait=True,
         logs=True,
@@ -695,7 +695,7 @@ def test_sklearn_with_network_config(sagemaker_session, sklearn_latest_version, 
     )
 
     sklearn_processor.run(
-        entry_point=script_path,
+        code=script_path,
         inputs=[ProcessingInput(source=input_file_path, destination="/opt/ml/processing/inputs/")],
         wait=False,
         logs=False,

--- a/tests/unit/test_processing.py
+++ b/tests/unit/test_processing.py
@@ -92,7 +92,7 @@ def test_sklearn_processor_with_required_parameters(
         sagemaker_session=sagemaker_session,
     )
 
-    processor.run(entry_point="/local/path/to/processing_code.py")
+    processor.run(code="/local/path/to/processing_code.py")
 
     expected_args = _get_expected_args_modular_code(processor._current_job_name)
 
@@ -137,7 +137,7 @@ def test_sklearn_with_all_parameters(
 
     with patch("sagemaker.estimator.tar_and_upload_dir", return_value=uploaded_code):
         processor.run(
-            entry_point="processing_code.py",
+            code="processing_code.py",
             source_dir="/local/path/to/source_dir",
             dependencies=["/local/path/to/dep_01"],
             inputs=_get_data_inputs_all_parameters(),
@@ -200,7 +200,7 @@ def test_sklearn_with_all_parameters_via_run_args(
     )
 
     processor.run(
-        entry_point=run_args.code,
+        code=run_args.code,
         inputs=run_args.inputs,
         outputs=run_args.outputs,
         arguments=run_args.arguments,
@@ -223,11 +223,11 @@ def test_sklearn_with_all_parameters_via_run_args(
     # Verify the alternate command was applied successfully:
     framework_script = processor._generate_framework_script("processing_code.py")
     expected_invocation = f"{' '.join(custom_command)} processing_code.py"
-    assert f"\n{expected_invocation}" in framework_script, (
-        "Framework script should contain customized invocation:\n{}\n\nGot:\n{}".format(
-            expected_invocation,
-            framework_script,
-        )
+    assert (
+        f"\n{expected_invocation}" in framework_script
+    ), "Framework script should contain customized invocation:\n{}\n\nGot:\n{}".format(
+        expected_invocation,
+        framework_script,
     )
 
 
@@ -276,7 +276,7 @@ def test_sklearn_with_all_parameters_via_run_args_called_twice(
     )
 
     processor.run(
-        entry_point=run_args.code,
+        code=run_args.code,
         inputs=run_args.inputs,
         outputs=run_args.outputs,
         arguments=run_args.arguments,
@@ -838,7 +838,9 @@ def _get_data_outputs_all_parameters():
     ]
 
 
-def _get_expected_args_all_parameters_modular_code(job_name, code_s3_uri=MOCKED_S3_URI, instance_count=1):
+def _get_expected_args_all_parameters_modular_code(
+    job_name, code_s3_uri=MOCKED_S3_URI, instance_count=1
+):
     # Add something to inputs
     return {
         "inputs": [


### PR DESCRIPTION
*Issue #, if available:* #8

*Description of changes:* Revert `FrameworkProcessor.run(entry_point=...)` back to `FrameworkProcessor.run(code=...)` to stay consistent with the other processors.

*Testing done:* yes (unit & integ)
