### PR TITLE
Add HuggingFaceProcessor and fix local mode

### DIFF
--- a/src/sagemaker/huggingface/__init__.py
+++ b/src/sagemaker/huggingface/__init__.py
@@ -14,3 +14,4 @@
 from __future__ import absolute_import
 
 from sagemaker.huggingface.estimator import HuggingFace  # noqa: F401
+from sagemaker.huggingface.processing import HuggingFaceProcessor  # noqa:F401

--- a/src/sagemaker/huggingface/processing.py
+++ b/src/sagemaker/huggingface/processing.py
@@ -1,0 +1,132 @@
+# Copyright 2019-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""This module contains code related to HuggingFace Processors which are used for Processing jobs.
+
+These jobs let customers perform data pre-processing, post-processing, feature engineering,
+data validation, and model evaluation and interpretation on SageMaker.
+"""
+from __future__ import absolute_import
+
+from sagemaker.processing import FrameworkProcessor
+from sagemaker.huggingface.estimator import HuggingFace
+
+
+class HuggingFaceProcessor(FrameworkProcessor):
+    """Handles Amazon SageMaker processing tasks for jobs using HuggingFace containers."""
+
+    estimator_cls = HuggingFace
+
+    def __init__(
+        self,
+        role,
+        instance_count,
+        instance_type,
+        transformers_version=None,
+        tensorflow_version=None,
+        pytorch_version=None,
+        py_version="py36",
+        image_uri=None,
+        command=["python"],
+        volume_size_in_gb=30,
+        volume_kms_key=None,
+        output_kms_key=None,
+        code_location=None,
+        max_runtime_in_seconds=None,
+        base_job_name=None,
+        sagemaker_session=None,
+        env=None,
+        tags=None,
+        network_config=None,
+    ):
+        """This processor executes a Python script in a HuggingFace execution environment.
+
+        Unless ``image_uri`` is specified, the environment is an Amazon-built Docker container
+        that executes functions defined in the supplied ``code`` Python script.
+
+        The arguments have the same meaning as in ``FrameworkProcessor``, with the following
+        exceptions.
+
+        Args:
+            transformers_version (str): Transformers version you want to use for
+                executing your model training code. Defaults to ``None``. Required unless
+                ``image_uri`` is provided. The current supported version is ``4.4.2``.
+            tensorflow_version (str): TensorFlow version you want to use for
+                executing your model training code. Defaults to ``None``. Required unless
+                ``pytorch_version`` is provided. The current supported version is ``1.6.0``.
+            pytorch_version (str): PyTorch version you want to use for
+                executing your model training code. Defaults to ``None``. Required unless
+                ``tensorflow_version`` is provided. The current supported version is ``2.4.1``.
+            py_version (str): Python version you want to use for executing your model training
+                code. Defaults to ``None``. Required unless ``image_uri`` is provided.  If
+                using PyTorch, the current supported version is ``py36``. If using TensorFlow,
+                the current supported version is ``py37``.
+
+        .. tip::
+
+            You can find additional parameters for initializing this class at
+            :class:`~sagemaker.processing.FrameworkProcessor`.
+        """
+        self.pytorch_version = pytorch_version
+        self.tensorflow_version = tensorflow_version
+        super().__init__(
+            self.estimator_cls,
+            transformers_version,
+            role,
+            instance_count,
+            instance_type,
+            py_version,
+            image_uri,
+            command,
+            volume_size_in_gb,
+            volume_kms_key,
+            output_kms_key,
+            code_location,
+            max_runtime_in_seconds,
+            base_job_name,
+            sagemaker_session,
+            env,
+            tags,
+            network_config,
+        )
+
+    def _create_estimator(
+        self,
+        entry_point="",
+        source_dir=None,
+        dependencies=None,
+        git_config=None,
+    ):
+        """Override default estimator factory function for HuggingFace's different parameters
+
+        HuggingFace estimators have 3 framework version parameters instead of one: The version for
+        Transformers, PyTorch, and TensorFlow.
+        """
+        return self.estimator_cls(
+            transformers_version=self.framework_version,
+            tensorflow_version=self.tensorflow_version,
+            pytorch_version=self.pytorch_version,
+            py_version=self.py_version,
+            entry_point=entry_point,
+            source_dir=source_dir,
+            dependencies=dependencies,
+            git_config=git_config,
+            code_location=self.code_location,
+            enable_network_isolation=False,
+            image_uri=self.image_uri,
+            role=self.role,
+            instance_count=self.instance_count,
+            instance_type=self.instance_type,
+            sagemaker_session=self.sagemaker_session,
+            debugger_hook_config=False,
+            disable_profiler=True,
+        )

--- a/src/sagemaker/local/local_session.py
+++ b/src/sagemaker/local/local_session.py
@@ -475,10 +475,30 @@ class LocalSagemakerRuntimeClient(object):
 
 
 class LocalSession(Session):
-    """A LocalSession class definition."""
+    """A SageMaker ``Session`` class for Local Mode.
 
-    def __init__(self, boto_session=None, s3_endpoint_url=None):
+    This class provides alternative Local Mode implementations for the functionality of
+    :class:`~sagemaker.session.Session`.
+    """
+
+    def __init__(self, boto_session=None, s3_endpoint_url=None, disable_local_code=False):
+        """Create a Local SageMaker Session.
+
+        Args:
+            boto_session (boto3.session.Session): The underlying Boto3 session which AWS service
+                calls are delegated to (default: None). If not provided, one is created with
+                default AWS configuration chain.
+            s3_endpoint_url (str): Override the default endpoint URL for Amazon S3, if set
+                (default: None).
+            disable_local_code (bool): Set ``True`` to override the default AWS configuration
+                chain to disable the ``local.local_code`` setting, which may not be supported for
+                some SDK features (default: False).
+        """
         self.s3_endpoint_url = s3_endpoint_url
+        # We use this local variable to avoid disrupting the __init__->_initialize API of the
+        # parent class... But overwriting it after constructor won't do anything, so prefix _ to
+        # discourage external use:
+        self._disable_local_code = disable_local_code
 
         super(LocalSession, self).__init__(boto_session)
 
@@ -530,6 +550,8 @@ class LocalSession(Session):
                 raise e
 
             self.config = yaml.load(open(sagemaker_config_file, "r"))
+            if self._disable_local_code and "local" in self.config:
+                self.config["local"]["local_code"] = False
 
     def logs_for_job(self, job_name, wait=False, poll=5, log_type="All"):
         """A no-op method meant to override the sagemaker client.

--- a/src/sagemaker/processing.py
+++ b/src/sagemaker/processing.py
@@ -1298,10 +1298,15 @@ class FrameworkProcessor(ScriptProcessor):
         self.framework_version = framework_version
         self.py_version = py_version
 
-        image_uri, base_job_name = self._pre_init_normalization(
-            instance_type, image_uri, base_job_name, sagemaker_session
-        )
-
+        # 1. To finalize/normalize the image_uri or base_job_name, we need to create an
+        #    estimator_cls instance.
+        # 2. We want to make it easy for children of FrameworkProcessor to override estimator
+        #    creation via a function (to create FrameworkProcessors for Estimators that may have
+        #    different signatures - like HuggingFace or others in future).
+        # 3. Super-class __init__ doesn't (currently) do anything with these params besides
+        #    storing them
+        #
+        # Therefore we'll init the superclass first and then customize the setup after:
         super().__init__(
             role=role,
             image_uri=image_uri,
@@ -1318,6 +1323,7 @@ class FrameworkProcessor(ScriptProcessor):
             tags=tags,
             network_config=network_config,
         )
+
         # This subclass uses the "code" input for actual payload and the ScriptProcessor parent's
         # functionality for uploading just a small entrypoint script to invoke it.
         self._CODE_CONTAINER_INPUT_NAME = "entrypoint"
@@ -1326,38 +1332,45 @@ class FrameworkProcessor(ScriptProcessor):
             code_location[:-1] if (code_location and code_location.endswith("/")) else code_location
         )
 
-    def _pre_init_normalization(
-        self,
-        instance_type: str,
-        image_uri: Optional[str] = None,
-        base_job_name: Optional[str] = None,
-        sagemaker_session: Optional[str] = None,
-    ) -> Tuple[str, str]:
-        """Normalize job name and container image uri."""
-        # Normalize base_job_name
-        if base_job_name is None:
-            base_job_name = self.estimator_cls._framework_name
+        if image_uri is None or base_job_name is None:
+            # For these default configuration purposes, we don't need the optional args:
+            est = self._create_estimator()
+            if image_uri is None:
+                self.image_uri = est.training_image_uri()
             if base_job_name is None:
-                logger.warning("Framework name is None. Please check with the maintainer.")
-                base_job_name = str(base_job_name)  # Keep mypy happy.
+                self.base_job_name = est.base_job_name or estimator_cls._framework_name
+                if base_job_name is None:
+                    base_job_name = "framework-processor"
 
-        # Normalize image uri.
-        if image_uri is None:
-            # Estimator used only to probe image uri, so can get away with some dummy values.
-            est = self.estimator_cls(
-                framework_version=self.framework_version,
-                instance_type=instance_type,
-                py_version=self.py_version,
-                image_uri=image_uri,
-                entry_point="",
-                role="",
-                enable_network_isolation=False,
-                instance_count=1,  # SKLearn estimator explicitly disables instance_count>1
-                sagemaker_session=sagemaker_session,
-            )
-            image_uri = est.training_image_uri()
-
-        return image_uri, base_job_name
+    def _create_estimator(
+        self,
+        entry_point="",
+        source_dir=None,
+        dependencies=None,
+        git_config=None,
+    ):
+        """Instantiate the Framework Estimator that backs this Processor"""
+        return self.estimator_cls(
+            framework_version=self.framework_version,
+            py_version=self.py_version,
+            entry_point=entry_point,
+            source_dir=source_dir,
+            dependencies=dependencies,
+            git_config=git_config,
+            code_location=self.code_location,
+            enable_network_isolation=False,  # True -> uploads to input channel. Not what we want!
+            image_uri=self.image_uri,
+            role=self.role,
+            # Estimator instance_count doesn't currently matter to FrameworkProcessor, and the
+            # SKLearn Framework Estimator requires instance_type==1. So here we hard-wire it to 1,
+            # but if it matters in future perhaps we could take self.instance_count here and have
+            # SKLearnProcessor override this function instead:
+            instance_count=1,
+            instance_type=self.instance_type,
+            sagemaker_session=self.sagemaker_session,
+            debugger_hook_config=False,
+            disable_profiler=True,
+        )
 
     def get_run_args(
         self,
@@ -1623,22 +1636,11 @@ class FrameworkProcessor(ScriptProcessor):
         """Upload payload sourcedir.tar.gz to S3."""
         # A new estimator instance is required, because each call to ScriptProcessor.run() can
         # use different codes.
-        estimator = self.estimator_cls(
+        estimator = self._create_estimator(
             entry_point=entry_point,
             source_dir=source_dir,
             dependencies=dependencies,
             git_config=git_config,
-            framework_version=self.framework_version,
-            py_version=self.py_version,
-            code_location=self.code_location,  # Upload to <code_loc>/jobname/output/source.tar.gz
-            enable_network_isolation=False,  # If true, uploads to input channel. Not what we want!
-            image_uri=self.image_uri,  # The image uri is already normalized by this point.
-            role=self.role,
-            instance_type=self.instance_type,
-            instance_count=1,
-            sagemaker_session=self.sagemaker_session,
-            debugger_hook_config=False,
-            disable_profiler=True,
         )
 
         estimator._prepare_for_training(job_name=job_name)

--- a/src/sagemaker/processing.py
+++ b/src/sagemaker/processing.py
@@ -128,7 +128,8 @@ class Processor(object):
 
         if self.instance_type in ("local", "local_gpu"):
             if not isinstance(sagemaker_session, LocalSession):
-                sagemaker_session = LocalSession()
+                # Until Local Mode Processing supports local code, we need to disable it:
+                sagemaker_session = LocalSession(disable_local_code=True)
 
         self.sagemaker_session = sagemaker_session or Session()
 
@@ -1568,10 +1569,11 @@ class FrameworkProcessor(ScriptProcessor):
 
         local_code = get_config_value("local.local_code", self.sagemaker_session.config)
         if self.sagemaker_session.local_mode and local_code:
-            # TODO: Can we be more prescriptive about how to not trigger this error?
-            # How can user or us force a local mode `Estimator` to run with `local_code=False`?
             raise RuntimeError(
-                "Local *code* is not currently supported for SageMaker Processing in Local Mode"
+                "SageMaker Processing Local Mode does not currently support 'local code' mode. "
+                "Please use a LocalSession created with disable_local_code=True, or leave "
+                "sagemaker_session unspecified when creating your Processor to have one set up "
+                "automatically."
             )
 
         # Upload the bootstrapping code as s3://.../jobname/source/runproc.sh.

--- a/tests/integ/test_local_mode.py
+++ b/tests/integ/test_local_mode.py
@@ -59,6 +59,11 @@ class LocalNoS3Session(LocalSession):
 
 
 @pytest.fixture(scope="module")
+def sagemaker_local_session_no_local_code(boto_session):
+    return LocalSession(boto_session=boto_session, disable_local_code=True)
+
+
+@pytest.fixture(scope="module")
 def sklearn_image_uri(
     sklearn_latest_version,
     sklearn_latest_py_version,
@@ -322,7 +327,7 @@ def test_local_transform_mxnet(
 
 
 @pytest.mark.local_mode
-def test_local_processing_sklearn(sagemaker_local_session, sklearn_latest_version):
+def test_local_processing_sklearn(sagemaker_local_session_no_local_code, sklearn_latest_version):
     script_path = os.path.join(DATA_DIR, "dummy_script.py")
     input_file_path = os.path.join(DATA_DIR, "dummy_input.txt")
 
@@ -332,7 +337,7 @@ def test_local_processing_sklearn(sagemaker_local_session, sklearn_latest_versio
         instance_type="local",
         instance_count=1,
         command=["python3"],
-        sagemaker_session=sagemaker_local_session,
+        sagemaker_session=sagemaker_local_session_no_local_code,
     )
 
     sklearn_processor.run(
@@ -344,12 +349,12 @@ def test_local_processing_sklearn(sagemaker_local_session, sklearn_latest_versio
 
     job_description = sklearn_processor.latest_job.describe()
 
-    assert len(job_description["ProcessingInputs"]) == 2
+    assert len(job_description["ProcessingInputs"]) == 3
     assert job_description["ProcessingResources"]["ClusterConfig"]["InstanceCount"] == 1
     assert job_description["ProcessingResources"]["ClusterConfig"]["InstanceType"] == "local"
     assert job_description["AppSpecification"]["ContainerEntrypoint"] == [
-        "python3",
-        "/opt/ml/processing/input/code/dummy_script.py",
+        "/bin/bash",
+        "/opt/ml/processing/input/entrypoint/runproc.sh",
     ]
     assert job_description["RoleArn"] == "<no_role>"
 

--- a/tests/unit/sagemaker/huggingface/huggingface_utils.py
+++ b/tests/unit/sagemaker/huggingface/huggingface_utils.py
@@ -1,0 +1,36 @@
+# Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+from sagemaker import image_uris
+
+REGION = "us-east-1"
+GPU_INSTANCE_TYPE = "ml.p2.xlarge"
+
+
+def get_full_gpu_image_uri(
+    version,
+    base_framework_version,
+    region=REGION,
+    instance_type=GPU_INSTANCE_TYPE,
+):
+    return image_uris.retrieve(
+        "huggingface",
+        region,
+        version=version,
+        py_version="py36",
+        instance_type=instance_type,
+        image_scope="training",
+        base_framework_version=base_framework_version,
+        container_version="cu110-ubuntu18.04",
+    )

--- a/tests/unit/sagemaker/huggingface/test_estimator.py
+++ b/tests/unit/sagemaker/huggingface/test_estimator.py
@@ -18,8 +18,9 @@ import os
 import pytest
 from mock import MagicMock, Mock, patch
 
-from sagemaker import image_uris
 from sagemaker.huggingface import HuggingFace
+
+from .huggingface_utils import get_full_gpu_image_uri, GPU_INSTANCE_TYPE, REGION
 
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
@@ -31,13 +32,10 @@ TIMESTAMP = "2017-11-06-14:14:15.672"
 TIME = 1510006209.073025
 BUCKET_NAME = "mybucket"
 INSTANCE_COUNT = 1
-INSTANCE_TYPE = "ml.p2.xlarge"
 ACCELERATOR_TYPE = "ml.eia.medium"
 IMAGE_URI = "huggingface"
 JOB_NAME = "{}-{}".format(IMAGE_URI, TIMESTAMP)
 ROLE = "Dummy"
-REGION = "us-east-1"
-GPU = "ml.p2.xlarge"
 
 ENDPOINT_DESC = {"EndpointConfigName": "test-endpoint"}
 
@@ -75,19 +73,6 @@ def fixture_sagemaker_session():
     return session
 
 
-def _get_full_gpu_image_uri(version, base_framework_version):
-    return image_uris.retrieve(
-        "huggingface",
-        REGION,
-        version=version,
-        py_version="py36",
-        instance_type=GPU,
-        image_scope="training",
-        base_framework_version=base_framework_version,
-        container_version="cu110-ubuntu18.04",
-    )
-
-
 def _huggingface_estimator(
     sagemaker_session,
     framework_version,
@@ -107,7 +92,7 @@ def _huggingface_estimator(
         role=ROLE,
         sagemaker_session=sagemaker_session,
         instance_count=INSTANCE_COUNT,
-        instance_type=instance_type if instance_type else INSTANCE_TYPE,
+        instance_type=instance_type if instance_type else GPU_INSTANCE_TYPE,
         base_job_name=base_job_name,
         **kwargs,
     )
@@ -115,7 +100,7 @@ def _huggingface_estimator(
 
 def _create_train_job(version, base_framework_version):
     return {
-        "image_uri": _get_full_gpu_image_uri(version, base_framework_version),
+        "image_uri": get_full_gpu_image_uri(version, base_framework_version),
         "input_mode": "File",
         "input_config": [
             {
@@ -132,7 +117,7 @@ def _create_train_job(version, base_framework_version):
         "job_name": JOB_NAME,
         "output_config": {"S3OutputPath": "s3://{}/".format(BUCKET_NAME)},
         "resource_config": {
-            "InstanceType": GPU,
+            "InstanceType": GPU_INSTANCE_TYPE,
             "InstanceCount": 1,
             "VolumeSizeInGB": 30,
         },
@@ -176,7 +161,7 @@ def test_huggingface_invalid_args():
             entry_point=SCRIPT_PATH,
             role=ROLE,
             instance_count=INSTANCE_COUNT,
-            instance_type=INSTANCE_TYPE,
+            instance_type=GPU_INSTANCE_TYPE,
             transformers_version="4.2.1",
             pytorch_version="1.6",
             enable_sagemaker_metrics=False,
@@ -189,7 +174,7 @@ def test_huggingface_invalid_args():
             entry_point=SCRIPT_PATH,
             role=ROLE,
             instance_count=INSTANCE_COUNT,
-            instance_type=INSTANCE_TYPE,
+            instance_type=GPU_INSTANCE_TYPE,
             pytorch_version="1.6",
             enable_sagemaker_metrics=False,
         )
@@ -201,7 +186,7 @@ def test_huggingface_invalid_args():
             entry_point=SCRIPT_PATH,
             role=ROLE,
             instance_count=INSTANCE_COUNT,
-            instance_type=INSTANCE_TYPE,
+            instance_type=GPU_INSTANCE_TYPE,
             transformers_version="4.2.1",
             enable_sagemaker_metrics=False,
         )
@@ -213,7 +198,7 @@ def test_huggingface_invalid_args():
             entry_point=SCRIPT_PATH,
             role=ROLE,
             instance_count=INSTANCE_COUNT,
-            instance_type=INSTANCE_TYPE,
+            instance_type=GPU_INSTANCE_TYPE,
             transformers_version="4.2",
             pytorch_version="1.6",
             tensorflow_version="2.3",
@@ -239,7 +224,7 @@ def test_huggingface(
         role=ROLE,
         sagemaker_session=sagemaker_session,
         instance_count=INSTANCE_COUNT,
-        instance_type=INSTANCE_TYPE,
+        instance_type=GPU_INSTANCE_TYPE,
         transformers_version=huggingface_training_version,
         pytorch_version=huggingface_pytorch_version,
         enable_sagemaker_metrics=False,

--- a/tests/unit/sagemaker/huggingface/test_processing.py
+++ b/tests/unit/sagemaker/huggingface/test_processing.py
@@ -1,0 +1,146 @@
+# Copyright 2019-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import pytest
+from mock import Mock, patch, MagicMock
+
+from sagemaker.huggingface.processing import HuggingFaceProcessor
+from sagemaker.fw_utils import UploadedCode
+
+from .huggingface_utils import get_full_gpu_image_uri, GPU_INSTANCE_TYPE, REGION
+
+BUCKET_NAME = "mybucket"
+ROLE = "arn:aws:iam::012345678901:role/SageMakerRole"
+ECR_HOSTNAME = "ecr.us-west-2.amazonaws.com"
+CUSTOM_IMAGE_URI = "012345678901.dkr.ecr.us-west-2.amazonaws.com/my-custom-image-uri"
+MOCKED_S3_URI = "s3://mocked_s3_uri_from_upload_data"
+
+
+@pytest.fixture(autouse=True)
+def mock_create_tar_file():
+    with patch("sagemaker.utils.create_tar_file", MagicMock()) as create_tar_file:
+        yield create_tar_file
+
+
+@pytest.fixture()
+def sagemaker_session():
+    boto_mock = Mock(name="boto_session", region_name=REGION)
+    session_mock = MagicMock(
+        name="sagemaker_session",
+        boto_session=boto_mock,
+        boto_region_name=REGION,
+        config=None,
+        local_mode=False,
+    )
+    session_mock.default_bucket = Mock(name="default_bucket", return_value=BUCKET_NAME)
+
+    session_mock.upload_data = Mock(name="upload_data", return_value=MOCKED_S3_URI)
+    session_mock.download_data = Mock(name="download_data")
+    session_mock.expand_role.return_value = ROLE
+    return session_mock
+
+
+@pytest.fixture()
+def uploaded_code(
+    s3_prefix="s3://mocked_s3_uri_from_upload_data/my_job_name/source/sourcedir.tar.gz",
+    script_name="processing_code.py",
+):
+    return UploadedCode(s3_prefix=s3_prefix, script_name=script_name)
+
+
+@patch("sagemaker.utils._botocore_resolver")
+@patch("os.path.exists", return_value=True)
+@patch("os.path.isfile", return_value=True)
+def test_huggingface_processor_with_required_parameters(
+    exists_mock,
+    isfile_mock,
+    botocore_resolver,
+    sagemaker_session,
+    huggingface_training_version,
+    huggingface_pytorch_version,
+):
+    botocore_resolver.return_value.construct_endpoint.return_value = {"hostname": ECR_HOSTNAME}
+
+    processor = HuggingFaceProcessor(
+        role=ROLE,
+        instance_type=GPU_INSTANCE_TYPE,
+        transformers_version=huggingface_training_version,
+        pytorch_version=huggingface_pytorch_version,
+        instance_count=1,
+        sagemaker_session=sagemaker_session,
+    )
+
+    processor.run(code="/local/path/to/processing_code.py")
+
+    expected_args = _get_expected_args_modular_code(processor._current_job_name)
+    expected_args["app_specification"]["ImageUri"] = get_full_gpu_image_uri(
+        huggingface_training_version,
+        f"pytorch{huggingface_pytorch_version}",
+    )
+
+    sagemaker_session.process.assert_called_with(**expected_args)
+
+
+def _get_expected_args_modular_code(job_name, code_s3_uri=f"s3://{BUCKET_NAME}"):
+    return {
+        "inputs": [
+            {
+                "InputName": "code",
+                "AppManaged": False,
+                "S3Input": {
+                    "S3Uri": f"{code_s3_uri}/{job_name}/source/sourcedir.tar.gz",
+                    "LocalPath": "/opt/ml/processing/input/code/",
+                    "S3DataType": "S3Prefix",
+                    "S3InputMode": "File",
+                    "S3DataDistributionType": "FullyReplicated",
+                    "S3CompressionType": "None",
+                },
+            },
+            {
+                "InputName": "entrypoint",
+                "AppManaged": False,
+                "S3Input": {
+                    "S3Uri": f"{code_s3_uri}/{job_name}/source/runproc.sh",
+                    "LocalPath": "/opt/ml/processing/input/entrypoint",
+                    "S3DataType": "S3Prefix",
+                    "S3InputMode": "File",
+                    "S3DataDistributionType": "FullyReplicated",
+                    "S3CompressionType": "None",
+                },
+            },
+        ],
+        "output_config": {"Outputs": []},
+        "experiment_config": None,
+        "job_name": job_name,
+        "resources": {
+            "ClusterConfig": {
+                "InstanceType": GPU_INSTANCE_TYPE,
+                "InstanceCount": 1,
+                "VolumeSizeInGB": 30,
+            }
+        },
+        "stopping_condition": None,
+        "app_specification": {
+            "ImageUri": CUSTOM_IMAGE_URI,
+            "ContainerEntrypoint": [
+                "/bin/bash",
+                "/opt/ml/processing/input/entrypoint/runproc.sh",
+            ],
+        },
+        "environment": None,
+        "network_config": None,
+        "role_arn": ROLE,
+        "tags": None,
+        "experiment_config": None,
+    }

--- a/tests/unit/test_processing.py
+++ b/tests/unit/test_processing.py
@@ -31,6 +31,7 @@ from sagemaker.processing import (
 )
 from sagemaker.sklearn.processing import SKLearnProcessor
 from sagemaker.pytorch.processing import PyTorchProcessor
+from sagemaker.utils import get_config_value
 from sagemaker.xgboost.processing import XGBoostEstimator
 from sagemaker.network import NetworkConfig
 from sagemaker.processing import FeatureStoreOutput
@@ -159,6 +160,20 @@ def test_sklearn_with_all_parameters(
     expected_args["app_specification"]["ImageUri"] = sklearn_image_uri
 
     sagemaker_session.process.assert_called_with(**expected_args)
+
+
+
+def test_local_mode_disables_local_code_by_default(sklearn_latest_version):
+    processor = SKLearnProcessor(
+        framework_version=sklearn_latest_version,
+        role=ROLE,
+        instance_count=1,
+        instance_type="local",
+    )
+
+    # Most tests use a fixture for sagemaker_session for consistent behaviour, so this unit test
+    # checks that the default initialization disables unsupported 'local_code' mode:
+    assert not get_config_value("local.local_code", processor.sagemaker_session.config)
 
 
 @patch("sagemaker.utils._botocore_resolver")


### PR DESCRIPTION
**EDIT:** I had a bit of extra time so also stacked on a second commit to un-break local mode...

**Issue #, if available:** N/A

**Description of changes:**

1. Add a `HuggingFaceProcessor` class for the HuggingFace Transformers framework
2. To enable (1), somewhat refactor the `FrameworkProcessor` constructor and the way `Estimator`s are created by `FrameworkProcessor`s
    - The `HuggingFace` Estimator has a somewhat different signature to standard framework estimators, which I suppose might be true in future in other cases too (especially if, for example, users have derived their own `Framework` classes and want to build `FrameworkProcessors` to work with them)
    - From this, I infer it's better to dedicate a (private) method in `FrameworkProcessor` to instantiatng objects of `estimator_cls` - rather than doing it differently within different functions as we did before. This way, it's easier for a derived class to override.
    - Simplify the { preprocess, superclass.init, postprocess } structure of `FrameworkProcessor.__init__` to a more straightforward and customizable, decorator-like pattern of {superclass.init, postprocess}.
3. Add basic unit & integration tests

**Testing done:**

- All unit tests pass
- Newly-added and all `test_processing` integration tests pass

**Notes:**

Might need to move some tests around: I think we need to agree on which tests we put service-wise under "processing", and which we put framework-wise.

At the moment I think I'd argue to:

- Obviously keep underlying `ScriptProcessor`/etc class tests in `test_processing` 
- Put basic, per-framework functionality tests like these under the frameworks as I've done here - to try and encourage developers to think about Processing as a capability of all the frameworks, rather than just a separate feature.
    - i.e. moving a couple of the higher-level `SKLearnProcessor` tests under `test_sklearn`.
- Keep tests which are actually exercising `FrameworkProcessor` more deeply but rely on having a concrete framework to work with (i.e. what we're currently doing with having *lots* of `SKLearnProcessor` tests) in the central `test_processing` area

...But maybe others think it's just better to keep everything under a huge collection of processor tests?