### PR TITLE
removed unnecessary import

### DIFF
--- a/tests/unit/test_processing.py
+++ b/tests/unit/test_processing.py
@@ -11,7 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
-from build.lib.sagemaker.local import image
 from platform import python_version
 
 import pytest


### PR DESCRIPTION
*Issue #, if available:*
Issue #28 

*Description of changes:*
Removed unused import.

*Testing done:*

```
PASSED tests/unit/test_processing.py::test_processor_with_all_parameters
PASSED tests/unit/test_processing.py::test_processing_job_from_processing_arn
PASSED tests/unit/test_processing.py::test_extend_processing_args
SKIPPED [2] tests/conftest.py:253: Skipping XGBoost algorithm version.
FAILED tests/unit/test_processing.py::test_local_mode_disables_local_code_by_default[0.23-1]
================= 1 failed, 188 passed, 2 skipped in 3.52s ==================
```

