### PR TITLE
Made test local processor to not depend on region setting

### DIFF
--- a/tests/unit/test_processing.py
+++ b/tests/unit/test_processing.py
@@ -165,10 +165,10 @@ def test_sklearn_with_all_parameters(
     sagemaker_session.process.assert_called_with(**expected_args)
 
 
-
-def test_local_mode_disables_local_code_by_default(sklearn_latest_version):
-    processor = SKLearnProcessor(
-        framework_version=sklearn_latest_version,
+@patch("sagemaker.local.LocalSession.__init__", return_value=None)
+def test_local_mode_disables_local_code_by_default(localsession_mock):
+    Processor(
+        image_uri="",
         role=ROLE,
         instance_count=1,
         instance_type="local",
@@ -176,7 +176,7 @@ def test_local_mode_disables_local_code_by_default(sklearn_latest_version):
 
     # Most tests use a fixture for sagemaker_session for consistent behaviour, so this unit test
     # checks that the default initialization disables unsupported 'local_code' mode:
-    assert not get_config_value("local.local_code", processor.sagemaker_session.config)
+    localsession_mock.assert_called_with(disable_local_code=True)
 
 
 @patch("sagemaker.utils._botocore_resolver")


### PR DESCRIPTION
*Issue #, if available:* Resolve #26

*Description of changes:*  Fix test local processor which were failing when AWS profile does not set a region.

*Testing done:*

```bash
% pytest tests/unit/test_processing.py::test_local_mode_disables_local_code_by_default
=============================================== test session starts ================================================
platform darwin -- Python 3.9.1, pytest-6.0.2, py-1.10.0, pluggy-0.13.1
rootdir: /Users/marcverd/src/github/sagemaker-python-sdk, configfile: tox.ini
plugins: rerunfailures-9.1.1, cov-2.11.1, xdist-2.2.1, timeout-1.4.2, forked-1.3.0
collected 1 item                                                                                                   

tests/unit/test_processing.py .                                                                              [100%]

================================================ 1 passed in 0.18s =================================================
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
